### PR TITLE
GuidePhoto 모델 정의 및 마이그레이션

### DIFF
--- a/GuideCam.xcodeproj/project.pbxproj
+++ b/GuideCam.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		3E1429192DCC896800345FBD /* RealmConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1429182DCC896800345FBD /* RealmConfiguration.swift */; };
 		3E14291A2DCC896800345FBD /* GuidePhotoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1429172DCC896800345FBD /* GuidePhotoEntity.swift */; };
 		3E14291C2DCC899200345FBD /* GuidePhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E14291B2DCC899200345FBD /* GuidePhoto.swift */; };
+		3E1429322DCC9BF600345FBD /* GuideCamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E14292F2DCC9BF600345FBD /* GuideCamTests.swift */; };
+		3E1429332DCC9BF600345FBD /* RealmMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1429302DCC9BF600345FBD /* RealmMigrationTests.swift */; };
 		3E21EB492DA501F200FB9881 /* GuideEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E21EB482DA501F200FB9881 /* GuideEntity.swift */; };
 		3E21EB4B2DA502A400FB9881 /* GuideRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E21EB4A2DA502A400FB9881 /* GuideRepository.swift */; };
 		3E21EB4D2DA504AE00FB9881 /* GuideFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E21EB4C2DA504AE00FB9881 /* GuideFileManager.swift */; };
@@ -59,6 +61,16 @@
 		3EFA03192DA26BA60087A708 /* AppColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EFA03182DA26BA60087A708 /* AppColor.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		3E1429282DCC9BC200345FBD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3EE1EB652D9E47B000681B6B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3EE1EB6C2D9E47B000681B6B;
+			remoteInfo = GuideCam;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		3EE1EBEA2D9E845C00681B6B /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -77,6 +89,9 @@
 		3E1429172DCC896800345FBD /* GuidePhotoEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidePhotoEntity.swift; sourceTree = "<group>"; };
 		3E1429182DCC896800345FBD /* RealmConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmConfiguration.swift; sourceTree = "<group>"; };
 		3E14291B2DCC899200345FBD /* GuidePhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidePhoto.swift; sourceTree = "<group>"; };
+		3E1429242DCC9BC200345FBD /* GuideCamTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GuideCamTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3E14292F2DCC9BF600345FBD /* GuideCamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideCamTests.swift; sourceTree = "<group>"; };
+		3E1429302DCC9BF600345FBD /* RealmMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmMigrationTests.swift; sourceTree = "<group>"; };
 		3E21EB482DA501F200FB9881 /* GuideEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideEntity.swift; sourceTree = "<group>"; };
 		3E21EB4A2DA502A400FB9881 /* GuideRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideRepository.swift; sourceTree = "<group>"; };
 		3E21EB4C2DA504AE00FB9881 /* GuideFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideFileManager.swift; sourceTree = "<group>"; };
@@ -127,6 +142,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3E1429212DCC9BC200345FBD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3EE1EB6A2D9E47B000681B6B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -141,6 +163,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3E1429312DCC9BF600345FBD /* GuideCamTests */ = {
+			isa = PBXGroup;
+			children = (
+				3E14292F2DCC9BF600345FBD /* GuideCamTests.swift */,
+				3E1429302DCC9BF600345FBD /* RealmMigrationTests.swift */,
+			);
+			path = GuideCamTests;
+			sourceTree = "<group>";
+		};
 		3E21ECBC2DA6FB7F00FB9881 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -153,6 +184,7 @@
 			isa = PBXGroup;
 			children = (
 				3EE1EBB32D9E778300681B6B /* GuideCam */,
+				3E1429312DCC9BF600345FBD /* GuideCamTests */,
 				3EE1EB6E2D9E47B000681B6B /* Products */,
 			);
 			sourceTree = "<group>";
@@ -161,6 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				3EE1EB6D2D9E47B000681B6B /* GuideCam.app */,
+				3E1429242DCC9BC200345FBD /* GuideCamTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -456,6 +489,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		3E1429232DCC9BC200345FBD /* GuideCamTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3E14292A2DCC9BC200345FBD /* Build configuration list for PBXNativeTarget "GuideCamTests" */;
+			buildPhases = (
+				3E1429202DCC9BC200345FBD /* Sources */,
+				3E1429212DCC9BC200345FBD /* Frameworks */,
+				3E1429222DCC9BC200345FBD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3E1429292DCC9BC200345FBD /* PBXTargetDependency */,
+			);
+			name = GuideCamTests;
+			packageProductDependencies = (
+			);
+			productName = GuideCamTests;
+			productReference = 3E1429242DCC9BC200345FBD /* GuideCamTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		3EE1EB6C2D9E47B000681B6B /* GuideCam */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3EE1EB802D9E47B200681B6B /* Build configuration list for PBXNativeTarget "GuideCam" */;
@@ -490,6 +543,10 @@
 				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 1620;
 				TargetAttributes = {
+					3E1429232DCC9BC200345FBD = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = 3EE1EB6C2D9E47B000681B6B;
+					};
 					3EE1EB6C2D9E47B000681B6B = {
 						CreatedOnToolsVersion = 16.2;
 					};
@@ -515,11 +572,19 @@
 			projectRoot = "";
 			targets = (
 				3EE1EB6C2D9E47B000681B6B /* GuideCam */,
+				3E1429232DCC9BC200345FBD /* GuideCamTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3E1429222DCC9BC200345FBD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3EE1EB6B2D9E47B000681B6B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -532,6 +597,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3E1429202DCC9BC200345FBD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E1429322DCC9BF600345FBD /* GuideCamTests.swift in Sources */,
+				3E1429332DCC9BF600345FBD /* RealmMigrationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3EE1EB692D9E47B000681B6B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -584,6 +658,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		3E1429292DCC9BC200345FBD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3EE1EB6C2D9E47B000681B6B /* GuideCam */;
+			targetProxy = 3E1429282DCC9BC200345FBD /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
 		3EE1EBAE2D9E778300681B6B /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
@@ -596,6 +678,42 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		3E14292B2DCC9BC200345FBD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = CP9THWX4QS;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dana.GuideCamTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GuideCam.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/GuideCam";
+			};
+			name = Debug;
+		};
+		3E14292C2DCC9BC200345FBD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = CP9THWX4QS;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dana.GuideCamTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GuideCam.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/GuideCam";
+			};
+			name = Release;
+		};
 		3EE1EB812D9E47B200681B6B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -788,6 +906,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3E14292A2DCC9BC200345FBD /* Build configuration list for PBXNativeTarget "GuideCamTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3E14292B2DCC9BC200345FBD /* Debug */,
+				3E14292C2DCC9BC200345FBD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		3EE1EB682D9E47B000681B6B /* Build configuration list for PBXProject "GuideCam" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/GuideCam.xcodeproj/project.pbxproj
+++ b/GuideCam.xcodeproj/project.pbxproj
@@ -12,6 +12,11 @@
 		3E14291C2DCC899200345FBD /* GuidePhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E14291B2DCC899200345FBD /* GuidePhoto.swift */; };
 		3E1429322DCC9BF600345FBD /* GuideCamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E14292F2DCC9BF600345FBD /* GuideCamTests.swift */; };
 		3E1429332DCC9BF600345FBD /* RealmMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1429302DCC9BF600345FBD /* RealmMigrationTests.swift */; };
+		3E1429362DCC9E0B00345FBD /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3E1429352DCC9E0B00345FBD /* SnapKit */; };
+		3E1429382DCC9E1500345FBD /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3E1429372DCC9E1500345FBD /* RxCocoa */; };
+		3E14293A2DCC9E1800345FBD /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3E1429392DCC9E1800345FBD /* RxSwift */; };
+		3E14293C2DCC9E1C00345FBD /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3E14293B2DCC9E1C00345FBD /* RealmSwift */; };
+		3E14293E2DCC9E1D00345FBD /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 3E14293B2DCC9E1C00345FBD /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		3E21EB492DA501F200FB9881 /* GuideEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E21EB482DA501F200FB9881 /* GuideEntity.swift */; };
 		3E21EB4B2DA502A400FB9881 /* GuideRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E21EB4A2DA502A400FB9881 /* GuideRepository.swift */; };
 		3E21EB4D2DA504AE00FB9881 /* GuideFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E21EB4C2DA504AE00FB9881 /* GuideFileManager.swift */; };
@@ -72,6 +77,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		3E14293D2DCC9E1C00345FBD /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				3E14293E2DCC9E1D00345FBD /* RealmSwift in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3EE1EBEA2D9E845C00681B6B /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -146,6 +162,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3E14293C2DCC9E1C00345FBD /* RealmSwift in Frameworks */,
+				3E14293A2DCC9E1800345FBD /* RxSwift in Frameworks */,
+				3E1429382DCC9E1500345FBD /* RxCocoa in Frameworks */,
+				3E1429362DCC9E0B00345FBD /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,6 +192,13 @@
 			path = GuideCamTests;
 			sourceTree = "<group>";
 		};
+		3E1429342DCC9E0B00345FBD /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		3E21ECBC2DA6FB7F00FB9881 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -185,6 +212,7 @@
 			children = (
 				3EE1EBB32D9E778300681B6B /* GuideCam */,
 				3E1429312DCC9BF600345FBD /* GuideCamTests */,
+				3E1429342DCC9E0B00345FBD /* Frameworks */,
 				3EE1EB6E2D9E47B000681B6B /* Products */,
 			);
 			sourceTree = "<group>";
@@ -496,6 +524,7 @@
 				3E1429202DCC9BC200345FBD /* Sources */,
 				3E1429212DCC9BC200345FBD /* Frameworks */,
 				3E1429222DCC9BC200345FBD /* Resources */,
+				3E14293D2DCC9E1C00345FBD /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -504,6 +533,10 @@
 			);
 			name = GuideCamTests;
 			packageProductDependencies = (
+				3E1429352DCC9E0B00345FBD /* SnapKit */,
+				3E1429372DCC9E1500345FBD /* RxCocoa */,
+				3E1429392DCC9E1800345FBD /* RxSwift */,
+				3E14293B2DCC9E1C00345FBD /* RealmSwift */,
 			);
 			productName = GuideCamTests;
 			productReference = 3E1429242DCC9BC200345FBD /* GuideCamTests.xctest */;
@@ -963,6 +996,26 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		3E1429352DCC9E0B00345FBD /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3EE1EBDE2D9E840900681B6B /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+		3E1429372DCC9E1500345FBD /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3EE1EBE12D9E841900681B6B /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
+		3E1429392DCC9E1800345FBD /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3EE1EBE12D9E841900681B6B /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		3E14293B2DCC9E1C00345FBD /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3EE1EBE62D9E844E00681B6B /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
 		3EE1EBDF2D9E840900681B6B /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3EE1EBDE2D9E840900681B6B /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/GuideCam.xcodeproj/project.pbxproj
+++ b/GuideCam.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3E1429192DCC896800345FBD /* RealmConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1429182DCC896800345FBD /* RealmConfiguration.swift */; };
+		3E14291A2DCC896800345FBD /* GuidePhotoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1429172DCC896800345FBD /* GuidePhotoEntity.swift */; };
+		3E14291C2DCC899200345FBD /* GuidePhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E14291B2DCC899200345FBD /* GuidePhoto.swift */; };
 		3E21EB492DA501F200FB9881 /* GuideEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E21EB482DA501F200FB9881 /* GuideEntity.swift */; };
 		3E21EB4B2DA502A400FB9881 /* GuideRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E21EB4A2DA502A400FB9881 /* GuideRepository.swift */; };
 		3E21EB4D2DA504AE00FB9881 /* GuideFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E21EB4C2DA504AE00FB9881 /* GuideFileManager.swift */; };
@@ -71,6 +74,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3E1429172DCC896800345FBD /* GuidePhotoEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidePhotoEntity.swift; sourceTree = "<group>"; };
+		3E1429182DCC896800345FBD /* RealmConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmConfiguration.swift; sourceTree = "<group>"; };
+		3E14291B2DCC899200345FBD /* GuidePhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidePhoto.swift; sourceTree = "<group>"; };
 		3E21EB482DA501F200FB9881 /* GuideEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideEntity.swift; sourceTree = "<group>"; };
 		3E21EB4A2DA502A400FB9881 /* GuideRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideRepository.swift; sourceTree = "<group>"; };
 		3E21EB4C2DA504AE00FB9881 /* GuideFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideFileManager.swift; sourceTree = "<group>"; };
@@ -294,6 +300,8 @@
 			isa = PBXGroup;
 			children = (
 				3E21EB482DA501F200FB9881 /* GuideEntity.swift */,
+				3E1429172DCC896800345FBD /* GuidePhotoEntity.swift */,
+				3E1429182DCC896800345FBD /* RealmConfiguration.swift */,
 			);
 			path = Realm;
 			sourceTree = "<group>";
@@ -310,6 +318,7 @@
 			isa = PBXGroup;
 			children = (
 				3EFA03082DA000910087A708 /* Guide.swift */,
+				3E14291B2DCC899200345FBD /* GuidePhoto.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -540,6 +549,7 @@
 				3EFA02F52D9FF0130087A708 /* CustomCameraViewController.swift in Sources */,
 				3E21EB4D2DA504AE00FB9881 /* GuideFileManager.swift in Sources */,
 				3EFA03172DA26B840087A708 /* UIColor+Hex.swift in Sources */,
+				3E14291C2DCC899200345FBD /* GuidePhoto.swift in Sources */,
 				3EE1EBC82D9E788C00681B6B /* AppCoordinator.swift in Sources */,
 				3EFA02DC2D9FEF3A0087A708 /* AlbumCoordinator.swift in Sources */,
 				3EFA03092DA000910087A708 /* Guide.swift in Sources */,
@@ -556,6 +566,8 @@
 				3EFA02D62D9FED270087A708 /* TabBarCoordinator.swift in Sources */,
 				3EFA02F72D9FF02F0087A708 /* AlbumViewController.swift in Sources */,
 				3EFA03052D9FFE480087A708 /* GuideListView.swift in Sources */,
+				3E1429192DCC896800345FBD /* RealmConfiguration.swift in Sources */,
+				3E14291A2DCC896800345FBD /* GuidePhotoEntity.swift in Sources */,
 				3EFA03112DA123CC0087A708 /* ConfirmSaveGuideViewController.swift in Sources */,
 				3E83FB092DA3C73B0008892E /* UIImageView+Extension.swift in Sources */,
 				3E21EB512DA54C7900FB9881 /* ConfirmSaveGuideView.swift in Sources */,

--- a/GuideCam.xcodeproj/xcshareddata/xcschemes/GuideCam.xcscheme
+++ b/GuideCam.xcodeproj/xcshareddata/xcschemes/GuideCam.xcscheme
@@ -29,9 +29,22 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3E1429232DCC9BC200345FBD"
+               BuildableName = "GuideCamTests.xctest"
+               BlueprintName = "GuideCamTests"
+               ReferencedContainer = "container:GuideCam.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/GuideCam/Application/AppDelegate.swift
+++ b/GuideCam/Application/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import RealmSwift
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -13,6 +14,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Realm 설정
         RealmConfiguration.configure()
+        
+        // Realm 설정 검증 (Debug 모드에서만 실행)
+        #if DEBUG
+        RealmConfiguration.printCurrentSchemaVersion()
+        RealmConfiguration.validateMigration()
+        #endif
         
         // Override point for customization after application launch.
         

--- a/GuideCam/Application/AppDelegate.swift
+++ b/GuideCam/Application/AppDelegate.swift
@@ -10,9 +10,10 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Realm 설정
+        RealmConfiguration.configure()
+        
         // Override point for customization after application launch.
         
         let navBarAppearance = UINavigationBarAppearance()

--- a/GuideCam/Data/Realm/GuidePhotoEntity.swift
+++ b/GuideCam/Data/Realm/GuidePhotoEntity.swift
@@ -1,0 +1,26 @@
+import Foundation
+import RealmSwift
+
+final class GuidePhotoEntity: Object {
+    @Persisted(primaryKey: true) var id: ObjectId = ObjectId.generate()
+    @Persisted var guideId: String
+    @Persisted var assetLocalIdentifier: String
+    @Persisted var createdAt: Date = Date()
+    
+    convenience init(guideId: String, assetLocalIdentifier: String) {
+        self.init()
+        self.guideId = guideId
+        self.assetLocalIdentifier = assetLocalIdentifier
+    }
+}
+
+extension GuidePhotoEntity {
+    func toModel() -> GuidePhoto {
+        return GuidePhoto(
+            id: self.id.stringValue,
+            guideId: self.guideId,
+            assetLocalIdentifier: self.assetLocalIdentifier,
+            createdAt: self.createdAt
+        )
+    }
+} 

--- a/GuideCam/Data/Realm/RealmConfiguration.swift
+++ b/GuideCam/Data/Realm/RealmConfiguration.swift
@@ -8,14 +8,51 @@ enum RealmConfiguration {
         return Realm.Configuration(
             schemaVersion: schemaVersion,
             migrationBlock: { migration, oldSchemaVersion in
+                print("Migrating from version \(oldSchemaVersion) to \(schemaVersion)")
                 if oldSchemaVersion < schemaVersion {
-                    // GuidePhotoEntity가 자동으로 추가됨
+                    print("Adding GuidePhotoEntity to schema")
                 }
+            },
+            shouldCompactOnLaunch: { totalBytes, usedBytes in
+                print("Realm file size: \(totalBytes) bytes, used: \(usedBytes) bytes")
+                return false
             }
         )
     }
     
     static func configure() {
         Realm.Configuration.defaultConfiguration = configuration
+    }
+    
+    // MARK: - Debug Methods
+    
+    static func printCurrentSchemaVersion() {
+        do {
+            let realm = try Realm()
+            print("Current Schema Version: \(realm.configuration.schemaVersion)")
+        } catch {
+            print("Error accessing Realm: \(error)")
+        }
+    }
+    
+    static func validateMigration() {
+        do {
+            let realm = try Realm()
+            
+            // 기존 Guide 엔티티 확인
+            let guides = realm.objects(GuideEntity.self)
+            print("Existing guides count: \(guides.count)")
+            
+            // 새로운 GuidePhoto 엔티티 확인
+            let photos = realm.objects(GuidePhotoEntity.self)
+            print("New GuidePhoto count: \(photos.count)")
+            
+            // 스키마 정보 출력
+            print("Schema version: \(realm.configuration.schemaVersion)")
+            print("Schema types: \(realm.schema.objectSchema.map { $0.className })")
+            
+        } catch {
+            print("Migration validation error: \(error)")
+        }
     }
 } 

--- a/GuideCam/Data/Realm/RealmConfiguration.swift
+++ b/GuideCam/Data/Realm/RealmConfiguration.swift
@@ -1,0 +1,21 @@
+import Foundation
+import RealmSwift
+
+enum RealmConfiguration {
+    static let schemaVersion: UInt64 = 2
+    
+    static var configuration: Realm.Configuration {
+        return Realm.Configuration(
+            schemaVersion: schemaVersion,
+            migrationBlock: { migration, oldSchemaVersion in
+                if oldSchemaVersion < schemaVersion {
+                    // GuidePhotoEntity가 자동으로 추가됨
+                }
+            }
+        )
+    }
+    
+    static func configure() {
+        Realm.Configuration.defaultConfiguration = configuration
+    }
+} 

--- a/GuideCam/Domain/Model/GuidePhoto.swift
+++ b/GuideCam/Domain/Model/GuidePhoto.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct GuidePhoto {
+    let id: String
+    let guideId: String
+    let assetLocalIdentifier: String
+    let createdAt: Date
+} 

--- a/GuideCam/Presentation/TabBar/View/CustomTabBarView.swift
+++ b/GuideCam/Presentation/TabBar/View/CustomTabBarView.swift
@@ -22,7 +22,6 @@ final class CustomTabBarView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        print(#function, "여기다!!!!!!!!!!!")
         setupViews()
         setupLayout()
     }

--- a/GuideCamTests/GuideCamTests.swift
+++ b/GuideCamTests/GuideCamTests.swift
@@ -1,0 +1,35 @@
+//
+//  GuideCamTests.swift
+//  GuideCamTests
+//
+//  Created by 조다은 on 5/8/25.
+//
+
+import XCTest
+
+final class GuideCamTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/GuideCamTests/RealmMigrationTests.swift
+++ b/GuideCamTests/RealmMigrationTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import RealmSwift
+@testable import GuideCam
+
+class RealmMigrationTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // 테스트용 Realm 설정
+        Realm.Configuration.defaultConfiguration = Realm.Configuration(
+            inMemoryIdentifier: "test-realm",
+            schemaVersion: 1
+        )
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        // 테스트 후 Realm 정리
+        let realm = try! Realm()
+        try! realm.write {
+            realm.deleteAll()
+        }
+    }
+    
+    func testMigrationPreservesExistingData() {
+        // 기존 데이터 생성 (v1)
+        let realm = try! Realm()
+        try! realm.write {
+            let guide = GuideEntity()
+            guide.title = "Test Guide"
+            guide.thumbnailPath = "test/path"
+            guide.isFavorite = true
+            guide.isRecent = true
+            realm.add(guide)
+        }
+        
+        // 마이그레이션 실행 (v2)
+        RealmConfiguration.configure()
+        
+        // 데이터 검증
+        let migratedRealm = try! Realm()
+        let guides = migratedRealm.objects(GuideEntity.self)
+        
+        // 기존 데이터가 보존되었는지 확인
+        XCTAssertEqual(guides.count, 1)
+        XCTAssertEqual(guides.first?.title, "Test Guide")
+        XCTAssertEqual(guides.first?.thumbnailPath, "test/path")
+        XCTAssertEqual(guides.first?.isFavorite, true)
+        XCTAssertEqual(guides.first?.isRecent, true)
+        
+        // 새로운 스키마가 추가되었는지 확인
+        XCTAssertTrue(migratedRealm.schema.objectSchema.contains { $0.className == "GuidePhotoEntity" })
+    }
+    
+    func testGuidePhotoEntityCreation() {
+        // 마이그레이션 실행
+        RealmConfiguration.configure()
+        
+        let realm = try! Realm()
+        
+        // GuidePhotoEntity 생성 테스트
+        try! realm.write {
+            let photo = GuidePhotoEntity(guideId: "test-guide-id", assetLocalIdentifier: "test-asset-id")
+            realm.add(photo)
+        }
+        
+        // 데이터 검증
+        let photos = realm.objects(GuidePhotoEntity.self)
+        XCTAssertEqual(photos.count, 1)
+        XCTAssertEqual(photos.first?.guideId, "test-guide-id")
+        XCTAssertEqual(photos.first?.assetLocalIdentifier, "test-asset-id")
+    }
+} 


### PR DESCRIPTION
✅ 작업 내용
• GuidePhoto Realm 모델 생성
• id: ObjectId
• guideId: String — 연결된 가이드의 UUID
• assetLocalIdentifier: String — 사진의 PHAsset identifier
• createdAt: Date — 사진 저장 시간
• Realm 모델 파일 구조에 맞게 저장
• Schema 버전 업데이트 및 마이그레이션 처리